### PR TITLE
Add option to compress/archive multiple generated files

### DIFF
--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -13,12 +13,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	accessToken string
-	remoteHost  string
-	remotePort  int
-)
-
 var fetchCmd = &cobra.Command{
 	Use:   "fetch",
 	Short: "Fetch a config file from a remote instance of configurator",

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/OpenCHAMI/configurator/pkg/generator"
+	"github.com/OpenCHAMI/configurator/pkg/util"
 	"github.com/rodaine/table"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
@@ -26,11 +27,16 @@ var inspectCmd = &cobra.Command{
 			return strings.ToUpper(fmt.Sprintf(format, vals...))
 		}
 
-		// TODO: remove duplicate args from CLI
+		// remove duplicate clean paths from CLI
+		paths := make([]string, len(args))
+		for _, path := range args {
+			paths = append(paths, filepath.Clean(path))
+		}
+		paths = util.RemoveDuplicates(paths)
 
 		// load specific plugins from positional args
 		var generators = make(map[string]generator.Generator)
-		for _, path := range args {
+		for _, path := range paths {
 			err := filepath.Walk(path, func(path string, info fs.FileInfo, err error) error {
 				if err != nil {
 					return err

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,11 +10,14 @@ import (
 )
 
 var (
-	configPath string
-	config     configurator.Config
-	verbose    bool
-	targets    []string
-	outputPath string
+	configPath  string
+	config      configurator.Config
+	verbose     bool
+	targets     []string
+	outputPath  string
+	accessToken string
+	remoteHost  string
+	remotePort  int
 )
 
 var rootCmd = &cobra.Command{

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -35,11 +35,6 @@ var serveCmd = &cobra.Command{
 			}
 		}
 
-		// use config plugins if none supplied via CLI
-		if len(pluginPaths) <= 0 {
-			pluginPaths = append(pluginPaths, config.PluginDirs...)
-		}
-
 		// show config as JSON and generators if verbose
 		if verbose {
 			b, err := json.MarshalIndent(config, "", "  ")
@@ -60,15 +55,19 @@ var serveCmd = &cobra.Command{
 				Retries: config.Server.Jwks.Retries,
 			},
 			GeneratorParams: generator.Params{
-				Args:        args,
-				PluginPaths: pluginPaths,
+				Args:       args,
+				PluginPath: pluginPath,
 				// Target: target,  // NOTE: targets are set via HTTP requests (ex: curl http://configurator:3334/generate?target=dnsmasq)
 				Verbose: verbose,
 			},
 		}
+
+		// start listening with the server
 		err := server.Serve()
 		if errors.Is(err, http.ErrServerClosed) {
-			fmt.Printf("Server closed.")
+			if verbose {
+				fmt.Printf("Server closed.")
+			}
 		} else if err != nil {
 			fmt.Errorf("failed to start server: %v", err)
 			os.Exit(1)
@@ -79,7 +78,7 @@ var serveCmd = &cobra.Command{
 func init() {
 	serveCmd.Flags().StringVar(&config.Server.Host, "host", config.Server.Host, "set the server host")
 	serveCmd.Flags().IntVar(&config.Server.Port, "port", config.Server.Port, "set the server port")
-	serveCmd.Flags().StringSliceVar(&pluginPaths, "plugins", nil, "set the generator plugins directory path")
+	serveCmd.Flags().StringVar(&pluginPath, "plugin", "", "set the generator plugins directory path")
 	serveCmd.Flags().StringVar(&config.Server.Jwks.Uri, "jwks-uri", config.Server.Jwks.Uri, "set the JWKS url to fetch public key")
 	serveCmd.Flags().IntVar(&config.Server.Jwks.Retries, "jwks-fetch-retries", config.Server.Jwks.Retries, "set the JWKS fetch retry count")
 	rootCmd.AddCommand(serveCmd)

--- a/pkg/auth.go
+++ b/pkg/auth.go
@@ -8,25 +8,8 @@ import (
 	"slices"
 
 	"github.com/OpenCHAMI/jwtauth/v5"
-	"github.com/lestrrat-go/jwx/jwk"
+	"github.com/lestrrat-go/jwx/v2/jwk"
 )
-
-func VerifyClaims(testClaims []string, r *http.Request) (bool, error) {
-	// extract claims from JWT
-	_, claims, err := jwtauth.FromContext(r.Context())
-	if err != nil {
-		return false, fmt.Errorf("failed to get claims(s) from token: %v", err)
-	}
-
-	// verify that each one of the test claims are included
-	for _, testClaim := range testClaims {
-		_, ok := claims[testClaim]
-		if !ok {
-			return false, fmt.Errorf("failed to verify claim(s) from token: %s", testClaim)
-		}
-	}
-	return true, nil
-}
 
 func VerifyScope(testScopes []string, r *http.Request) (bool, error) {
 	// extract the scopes from JWT
@@ -111,4 +94,8 @@ func FetchPublicKeyFromURL(url string) (*jwtauth.JWTAuth, error) {
 	}
 
 	return tokenAuth, nil
+}
+
+func LoadAccessToken() {
+
 }

--- a/pkg/generator/plugins/dhcpd/dhcpd.go
+++ b/pkg/generator/plugins/dhcpd/dhcpd.go
@@ -37,7 +37,7 @@ func (g *Dhcpd) Generate(config *configurator.Config, opts ...util.Option) (gene
 	if client != nil {
 		eths, err = client.FetchEthernetInterfaces(opts...)
 		if err != nil {
-			return nil, fmt.Errorf("failed to fetch ethernet interfaces with client: %v", err)
+			return nil, fmt.Errorf("failed to fetch ethernet interfaces with client: %w", err)
 		}
 	}
 

--- a/pkg/util/params.go
+++ b/pkg/util/params.go
@@ -11,7 +11,7 @@ type Params map[string]any
 type Option func(Params)
 
 // Extract all parameters from the options passed as map[string]any.
-func GetParams(opts ...Option) Params {
+func ToDict(opts ...Option) Params {
 	params := Params{}
 	for _, opt := range opts {
 		opt(params)
@@ -45,8 +45,8 @@ func WithDefault[T any](v T) Option {
 	}
 }
 
-// Syntactic sugar generic function to get parameter from util.Params.
-func Get[T any](params Params, key string, opts ...Option) *T {
+// Sugary generic function to get parameter from util.Params.
+func Get[T any](params Params, key string) *T {
 	if v, ok := params[key].(T); ok {
 		return &v
 	}
@@ -54,4 +54,17 @@ func Get[T any](params Params, key string, opts ...Option) *T {
 		return &defaultValue
 	}
 	return nil
+}
+
+func GetOpt[T any](opts []Option, key string) *T {
+	return Get[T](ToDict(opts...), "required_claims")
+}
+
+func (p Params) GetVerbose() bool {
+	if verbose, ok := p["verbose"].(bool); ok {
+		return verbose
+	}
+
+	// default setting
+	return false
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,8 +1,10 @@
 package util
 
 import (
+	"archive/tar"
 	"bytes"
 	"cmp"
+	"compress/gzip"
 	"crypto/tls"
 	"fmt"
 	"io"
@@ -96,4 +98,65 @@ func CopyIf[T comparable](s []T, condition func(t T) bool) []T {
 		}
 	}
 	return f
+}
+
+func CreateArchive(files []string, buf io.Writer) error {
+	// Create new Writers for gzip and tar
+	// These writers are chained. Writing to the tar writer will
+	// write to the gzip writer which in turn will write to
+	// the "buf" writer
+	gw := gzip.NewWriter(buf)
+	defer gw.Close()
+	tw := tar.NewWriter(gw)
+	defer tw.Close()
+
+	// Iterate over files and add them to the tar archive
+	for _, file := range files {
+		err := addToArchive(tw, file)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func addToArchive(tw *tar.Writer, filename string) error {
+	// open file to write to archive
+	file, err := os.Open(filename)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	// get FileInfo for file size, mode, etc.
+	info, err := file.Stat()
+	if err != nil {
+		return err
+	}
+
+	// create a tar Header from the FileInfo data
+	header, err := tar.FileInfoHeader(info, info.Name())
+	if err != nil {
+		return err
+	}
+
+	// use full path as name (FileInfoHeader only takes the basename) to
+	// preserve directory structure
+	// see for more info: https://golang.org/src/archive/tar/common.go?#L626
+	header.Name = filename
+
+	// Write file header to the tar archive
+	err = tw.WriteHeader(header)
+	if err != nil {
+		return err
+	}
+
+	// copy file content to tar archive
+	_, err = io.Copy(tw, file)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -2,12 +2,14 @@ package util
 
 import (
 	"bytes"
+	"cmp"
 	"crypto/tls"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"os/exec"
+	"slices"
 	"strings"
 )
 
@@ -28,7 +30,7 @@ func IsDirectory(path string) (bool, error) {
 	// This returns an *os.FileInfo type
 	fileInfo, err := os.Stat(path)
 	if err != nil {
-		return false, fmt.Errorf("failed to stat path: %v", err)
+		return false, fmt.Errorf("failed to stat path (%s): %v", path, err)
 	}
 
 	// IsDir is short for fileInfo.Mode().IsDir()
@@ -63,7 +65,7 @@ func MakeRequest(url string, httpMethod string, body []byte, headers map[string]
 // NOTE: This currently requires git to be installed.
 // TODO: Change how this is done to not require executing a command.
 func GitCommit() string {
-	c := exec.Command("git", "rev-parse", "HEAD")
+	c := exec.Command("git", "rev-parse", "--short=8", "HEAD")
 	stdout, err := c.Output()
 	if err != nil {
 		return ""
@@ -78,6 +80,11 @@ func RemoveIndex[T comparable](s []T, index int) []T {
 	ret := make([]T, 0)
 	ret = append(ret, s[:index]...)
 	return append(ret, s[index+1:]...)
+}
+
+func RemoveDuplicates[T cmp.Ordered](s []T) []T {
+	slices.Sort(s)
+	return slices.Compact(s)
 }
 
 // General function to copy elements from slice if condition is true.


### PR DESCRIPTION
This PR adds an option to add a collection of multiple files generated into a single compressed archive. The archive is saved using the `--output-path` flag with the `.tar.gz` extension being adding automatically.