### PR TITLE
Build default plugins directly into the binary executable

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -5,12 +5,14 @@ before:
     - go mod download
     - make plugins
 builds:
-  - env:
-      - CGO_ENABLED=1
+  - id: "configurator"
     goos:
-      - linux
+        - linux
     goarch:
       - amd64
+      - arm64
+    flags:
+        - -tags:all
 archives:
   - format: tar.gz
     # this name template makes the OS and Arch compatible with the results of uname.

--- a/pkg/generator/conman.go
+++ b/pkg/generator/conman.go
@@ -1,10 +1,9 @@
-package main
+package generator
 
 import (
 	"fmt"
 
 	configurator "github.com/OpenCHAMI/configurator/pkg"
-	"github.com/OpenCHAMI/configurator/pkg/generator"
 	"github.com/OpenCHAMI/configurator/pkg/util"
 )
 
@@ -22,10 +21,10 @@ func (g *Conman) GetDescription() string {
 	return fmt.Sprintf("Configurator generator plugin for '%s'.", g.GetName())
 }
 
-func (g *Conman) Generate(config *configurator.Config, opts ...util.Option) (generator.FileMap, error) {
+func (g *Conman) Generate(config *configurator.Config, opts ...util.Option) (FileMap, error) {
 	var (
-		params                                   = generator.GetParams(opts...)
-		client                                   = generator.GetClient(params)
+		params                                   = GetParams(opts...)
+		client                                   = GetClient(params)
 		targetKey                                = params["target"].(string) // required param
 		target                                   = config.Targets[targetKey]
 		eps       []configurator.RedfishEndpoint = nil
@@ -56,7 +55,7 @@ func (g *Conman) Generate(config *configurator.Config, opts ...util.Option) (gen
 	consoles += "# ====================================================================="
 
 	// apply template substitutions and return output as byte array
-	return generator.ApplyTemplateFromFiles(generator.Mappings{
+	return ApplyTemplateFromFiles(Mappings{
 		"plugin_name":        g.GetName(),
 		"plugin_version":     g.GetVersion(),
 		"plugin_description": g.GetDescription(),
@@ -65,5 +64,3 @@ func (g *Conman) Generate(config *configurator.Config, opts ...util.Option) (gen
 		"consoles":           consoles,
 	}, target.TemplatePaths...)
 }
-
-var Generator Conman

--- a/pkg/generator/coredhcp.go
+++ b/pkg/generator/coredhcp.go
@@ -1,10 +1,12 @@
-package main
+//go:build coredhcp || plugins
+// +build coredhcp plugins
+
+package generator
 
 import (
 	"fmt"
 
 	configurator "github.com/OpenCHAMI/configurator/pkg"
-	"github.com/OpenCHAMI/configurator/pkg/generator"
 	"github.com/OpenCHAMI/configurator/pkg/util"
 )
 
@@ -22,8 +24,6 @@ func (g *CoreDhcp) GetDescription() string {
 	return fmt.Sprintf("Configurator generator plugin for '%s' to generate config files. (WIP)", g.GetName())
 }
 
-func (g *CoreDhcp) Generate(config *configurator.Config, opts ...util.Option) (generator.FileMap, error) {
+func (g *CoreDhcp) Generate(config *configurator.Config, opts ...util.Option) (FileMap, error) {
 	return nil, fmt.Errorf("plugin does not implement generation function")
 }
-
-var Generator CoreDhcp

--- a/pkg/generator/dhcpd.go
+++ b/pkg/generator/dhcpd.go
@@ -1,31 +1,30 @@
-package main
+package generator
 
 import (
 	"fmt"
 
 	configurator "github.com/OpenCHAMI/configurator/pkg"
-	"github.com/OpenCHAMI/configurator/pkg/generator"
 	"github.com/OpenCHAMI/configurator/pkg/util"
 )
 
-type Dhcpd struct{}
+type DHCPd struct{}
 
-func (g *Dhcpd) GetName() string {
+func (g *DHCPd) GetName() string {
 	return "dhcpd"
 }
 
-func (g *Dhcpd) GetVersion() string {
+func (g *DHCPd) GetVersion() string {
 	return util.GitCommit()
 }
 
-func (g *Dhcpd) GetDescription() string {
+func (g *DHCPd) GetDescription() string {
 	return fmt.Sprintf("Configurator generator plugin for '%s'.", g.GetName())
 }
 
-func (g *Dhcpd) Generate(config *configurator.Config, opts ...util.Option) (generator.FileMap, error) {
+func (g *DHCPd) Generate(config *configurator.Config, opts ...util.Option) (FileMap, error) {
 	var (
-		params                                         = generator.GetParams(opts...)
-		client                                         = generator.GetClient(params)
+		params                                         = GetParams(opts...)
+		client                                         = GetClient(params)
 		targetKey                                      = params["target"].(string)
 		target                                         = config.Targets[targetKey]
 		compute_nodes                                  = ""
@@ -64,7 +63,7 @@ func (g *Dhcpd) Generate(config *configurator.Config, opts ...util.Option) (gene
 			fmt.Printf("")
 		}
 	}
-	return generator.ApplyTemplateFromFiles(generator.Mappings{
+	return ApplyTemplateFromFiles(Mappings{
 		"plugin_name":        g.GetName(),
 		"plugin_version":     g.GetVersion(),
 		"plugin_description": g.GetDescription(),
@@ -72,5 +71,3 @@ func (g *Dhcpd) Generate(config *configurator.Config, opts ...util.Option) (gene
 		"node_entries":       "",
 	}, target.TemplatePaths...)
 }
-
-var Generator Dhcpd

--- a/pkg/generator/dnsmasq.go
+++ b/pkg/generator/dnsmasq.go
@@ -1,29 +1,28 @@
-package main
+package generator
 
 import (
 	"fmt"
 	"strings"
 
 	configurator "github.com/OpenCHAMI/configurator/pkg"
-	"github.com/OpenCHAMI/configurator/pkg/generator"
 	"github.com/OpenCHAMI/configurator/pkg/util"
 )
 
-type DnsMasq struct{}
+type DNSMasq struct{}
 
-func (g *DnsMasq) GetName() string {
+func (g *DNSMasq) GetName() string {
 	return "dnsmasq"
 }
 
-func (g *DnsMasq) GetVersion() string {
+func (g *DNSMasq) GetVersion() string {
 	return util.GitCommit()
 }
 
-func (g *DnsMasq) GetDescription() string {
+func (g *DNSMasq) GetDescription() string {
 	return fmt.Sprintf("Configurator generator plugin for '%s'.", g.GetName())
 }
 
-func (g *DnsMasq) Generate(config *configurator.Config, opts ...util.Option) (generator.FileMap, error) {
+func (g *DNSMasq) Generate(config *configurator.Config, opts ...util.Option) (FileMap, error) {
 	// make sure we have a valid config first
 	if config == nil {
 		return nil, fmt.Errorf("invalid config (config is nil)")
@@ -31,8 +30,8 @@ func (g *DnsMasq) Generate(config *configurator.Config, opts ...util.Option) (ge
 
 	// set all the defaults for variables
 	var (
-		params                                     = generator.GetParams(opts...)
-		client                                     = generator.GetClient(params)
+		params                                     = GetParams(opts...)
+		client                                     = GetClient(params)
 		targetKey                                  = params["target"].(string) // required param
 		target                                     = config.Targets[targetKey]
 		eths      []configurator.EthernetInterface = nil
@@ -74,12 +73,10 @@ func (g *DnsMasq) Generate(config *configurator.Config, opts ...util.Option) (ge
 	output += "# ====================================================================="
 
 	// apply template substitutions and return output as byte array
-	return generator.ApplyTemplateFromFiles(generator.Mappings{
+	return ApplyTemplateFromFiles(Mappings{
 		"plugin_name":        g.GetName(),
 		"plugin_version":     g.GetVersion(),
 		"plugin_description": g.GetDescription(),
 		"dhcp-hosts":         output,
 	}, target.TemplatePaths...)
 }
-
-var Generator DnsMasq

--- a/pkg/generator/example.go
+++ b/pkg/generator/example.go
@@ -1,4 +1,7 @@
-package main
+//go:build example || plugins
+// +build example plugins
+
+package generator
 
 import (
 	"fmt"

--- a/pkg/generator/hostfile.go
+++ b/pkg/generator/hostfile.go
@@ -1,10 +1,9 @@
-package main
+package generator
 
 import (
 	"fmt"
 
 	configurator "github.com/OpenCHAMI/configurator/pkg"
-	"github.com/OpenCHAMI/configurator/pkg/generator"
 	"github.com/OpenCHAMI/configurator/pkg/util"
 )
 
@@ -22,8 +21,6 @@ func (g *Hostfile) GetDescription() string {
 	return fmt.Sprintf("Configurator generator plugin for '%s'.", g.GetName())
 }
 
-func (g *Hostfile) Generate(config *configurator.Config, opts ...util.Option) (generator.FileMap, error) {
+func (g *Hostfile) Generate(config *configurator.Config, opts ...util.Option) (FileMap, error) {
 	return nil, fmt.Errorf("plugin does not implement generation function")
 }
-
-var Generator Hostfile

--- a/pkg/generator/powerman.go
+++ b/pkg/generator/powerman.go
@@ -1,10 +1,9 @@
-package main
+package generator
 
 import (
 	"fmt"
 
 	configurator "github.com/OpenCHAMI/configurator/pkg"
-	"github.com/OpenCHAMI/configurator/pkg/generator"
 	"github.com/OpenCHAMI/configurator/pkg/util"
 )
 
@@ -22,8 +21,6 @@ func (g *Powerman) GetDescription() string {
 	return fmt.Sprintf("Configurator generator plugin for '%s'.", g.GetName())
 }
 
-func (g *Powerman) Generate(config *configurator.Config, opts ...util.Option) (generator.FileMap, error) {
+func (g *Powerman) Generate(config *configurator.Config, opts ...util.Option) (FileMap, error) {
 	return nil, fmt.Errorf("plugin does not implement generation function")
 }
-
-var Generator Powerman

--- a/pkg/generator/syslog.go
+++ b/pkg/generator/syslog.go
@@ -1,10 +1,9 @@
-package main
+package generator
 
 import (
 	"fmt"
 
 	configurator "github.com/OpenCHAMI/configurator/pkg"
-	"github.com/OpenCHAMI/configurator/pkg/generator"
 	"github.com/OpenCHAMI/configurator/pkg/util"
 )
 
@@ -22,8 +21,6 @@ func (g *Syslog) GetDescription() string {
 	return fmt.Sprintf("Configurator generator plugin for '%s'.", g.GetName())
 }
 
-func (g *Syslog) Generate(config *configurator.Config, opts ...util.Option) (generator.FileMap, error) {
+func (g *Syslog) Generate(config *configurator.Config, opts ...util.Option) (FileMap, error) {
 	return nil, fmt.Errorf("plugin does not implement generation function")
 }
-
-var Generator Syslog

--- a/pkg/generator/warewulf.go
+++ b/pkg/generator/warewulf.go
@@ -1,4 +1,4 @@
-package main
+package generator
 
 import (
 	"fmt"
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	configurator "github.com/OpenCHAMI/configurator/pkg"
-	"github.com/OpenCHAMI/configurator/pkg/generator"
 	"github.com/OpenCHAMI/configurator/pkg/util"
 )
 
@@ -24,13 +23,13 @@ func (g *Warewulf) GetDescription() string {
 	return "Configurator generator plugin for 'warewulf' config files."
 }
 
-func (g *Warewulf) Generate(config *configurator.Config, opts ...util.Option) (generator.FileMap, error) {
+func (g *Warewulf) Generate(config *configurator.Config, opts ...util.Option) (FileMap, error) {
 	var (
-		params    = generator.GetParams(opts...)
-		client    = generator.GetClient(params)
+		params    = GetParams(opts...)
+		client    = GetClient(params)
 		targetKey = params["target"].(string)
 		target    = config.Targets[targetKey]
-		outputs   = make(generator.FileMap, len(target.FilePaths)+len(target.TemplatePaths))
+		outputs   = make(FileMap, len(target.FilePaths)+len(target.TemplatePaths))
 	)
 
 	// check if our client is included and is valid
@@ -72,11 +71,11 @@ func (g *Warewulf) Generate(config *configurator.Config, opts ...util.Option) (g
 	nodeEntries := ""
 
 	// load files and templates and copy to outputs
-	files, err := generator.LoadFiles(target.FilePaths...)
+	files, err := LoadFiles(target.FilePaths...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load files: %v", err)
 	}
-	templates, err := generator.ApplyTemplateFromFiles(generator.Mappings{
+	templates, err := ApplyTemplateFromFiles(Mappings{
 		"node_entries": nodeEntries,
 	}, target.TemplatePaths...)
 	if err != nil {
@@ -98,5 +97,3 @@ func (g *Warewulf) Generate(config *configurator.Config, opts ...util.Option) (g
 
 	return outputs, err
 }
-
-var Generator Warewulf


### PR DESCRIPTION
This PR changes how the default plugins are built. Instead of having each individual plugin built separately, they are now built into the executable itself. Therefore, this PR also adds a check for built-in generators first before perform a lookup with external plugins. No other changes were made to the plugin system itself, so it is still possible to create plugins externally and load them like before. 